### PR TITLE
feat: add support for OttoFMS OData proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ options:
     const connection = new Connection('example.com', new ClarisId('username', 'password'));
     ````  
 
+- Using OttoFMS Data API Key
+   ```typescript
+    import {OttoAPIKey, Connection} from 'fm-odata-client';
+  
+    const connection = new Connection('example.com', new OttoAPIKey('dk_1234567890'));
+    ````
+
 This will give you a connection instance which allows you to issue queries against the OData API.
 
 ### Note about FileMaker related OData issues

--- a/src/OttoFMS.ts
+++ b/src/OttoFMS.ts
@@ -1,0 +1,15 @@
+import type { Authentication } from "./Connection.js";
+
+class OttoAPIKey implements Authentication {
+    private readonly authorizationHeader: Promise<string>;
+
+    public constructor(apiKey: `dk_${string}`) {
+        this.authorizationHeader = Promise.resolve(`Bearer ${apiKey}`);
+    }
+
+    public async getAuthorizationHeader(): Promise<string> {
+        return this.authorizationHeader;
+    }
+}
+
+export default OttoAPIKey;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "./SchemaManager.js";
 export * from "./Table.js";
 
 export { default as BasicAuth } from "./BasicAuth.js";
+export { default as OttoAPIKey } from "./OttoFMS.js";
 export { default as Connection } from "./Connection.js";
 export { default as Database } from "./Database.js";
 export { default as SchemaManager } from "./SchemaManager.js";


### PR DESCRIPTION
OttoFMS 4.11 introduced support for API keys to proxy the OData API. This simple change will allow users to choose to use the OttoFMS proxy with an API key instead of credentials